### PR TITLE
Adding Boaz Sender to list the past "team" members.

### DIFF
--- a/pages/team.html
+++ b/pages/team.html
@@ -423,6 +423,10 @@
 		<h3>Contributed QUnit’s equiv method, which drives deepEqual</h3>
 	</li>
 	<li>
+		<h2>Boaz Sender</h2>
+		<h3>Content, Design and Web</h3>
+	</li>
+	<li>
 		<h2>David Serduke</h2>
 		<h3>Core</h3>
 	</li>


### PR DESCRIPTION
It was a "subteam" at the time, and I was never on the site then, but I see other people from that time listed, and @rworth told me to make a PR.
