### PR TITLE
jquery.org: added contact us link to info@jquery.org

### DIFF
--- a/pages/index.html
+++ b/pages/index.html
@@ -34,7 +34,7 @@
 		<ul>
 			<li><a href="/donate">Donate to jQuery today</a>. You can send a small or large amount via PayPal or by check. Every bit makes a difference.</li>
 			<li><a href="/join">Join the jQuery Foundation</a>. Individual members receive an annual membership gift such as a t-shirt, hoodie, or bag, depending on their membership level. Corporate members receive discounts on conference sponsorships and recognition at our many world-wide events. All members are recognized on our members page, <a href="/members">jquery.org/members</a>.</li>
-			<li><a href="http://contribute.jquery.org/">Contribute time or services.</a> Like any organization, we constantly need people to write code, maintain servers, write documentation, and many other tasks. If you or your company would like to donate time or services, please contact us.</li>
+			<li><a href="http://contribute.jquery.org/">Contribute time or services.</a> Like any organization, we constantly need people to write code, maintain servers, write documentation, and many other tasks. If you or your company would like to donate time or services, please <a href="mailto:info@jquery.org">contact us</a>.</li>
 			<li><a href="/credit-card/">Apply for a jQuery credit card.</a> For every person who receives a jQuery credit card, the jQuery Foundation gets $50. The card has no annual fee and gives you reward points for purchases.</li>
 		</ul>
 	</div>


### PR DESCRIPTION
This is to provide individuals and companies with a clear method/way to contact us
