### PR TITLE
Corrected years for historical events

### DIFF
--- a/pages/history.html
+++ b/pages/history.html
@@ -128,11 +128,9 @@
 
 		<h3>March</h3>
 		<ul>
-			<li><strong>March 23rd, 2012</strong> - jQuery UI 1.8 adds position, button, autocomplete, new widget factory, lighter core.</li>
 			<li>
 				<strong>March 21st, 2012</strong> - <a href="http://blog.jquery.com/2012/03/21/jquery-1-7-2-released/" title="jQuery 1.7.2 released">jQuery 1.7.2 released</a>
 			</li>
-			<li><strong>March 16th, 2012</strong> - Microsoft to Expand its Collaboration with the jQuery Community</li>
 			<li>
 				<strong>March 6, 2012</strong> - <a href="http://blog.jquery.com/2012/03/06/announcing-the-jquery-foundation/" title="jQuery Foundation Announced">jQuery Foundation Announced</a>
 			</li>


### PR DESCRIPTION
Some of the entries for year 2012 had incorrect dates (2013 and 2010 instead of 2012)
