### PR TITLE
Added grunt task to copy docs from the jquery/foundation repo.

### DIFF
--- a/grunt.js
+++ b/grunt.js
@@ -29,6 +29,9 @@ grunt.initConfig({
 			tasks: "deploy"
 		}
 	},
+	"copy-foundation-docs": {
+		"travel-policy.md": "travel-policy.md"
+	},
 	"build-pages": {
 		all: grunt.file.expandFiles( "pages/**/*.html" )
 	},
@@ -38,6 +41,35 @@ grunt.initConfig({
 	wordpress: grunt.utils._.extend({
 		dir: "dist/wordpress"
 	}, grunt.file.readJSON( "config.json" ) )
+});
+
+grunt.registerMultiTask( "copy-foundation-docs", "", function() {
+	var github = require( "github-request" ),
+		done = this.async(),
+		src = this.file.src,
+		dest = "pages/" + this.file.dest,
+		token = grunt.config( "wordpress.githubToken" );
+
+	if ( !token ) {
+		grunt.log.error( "Missing githubToken in config.json" );
+		return done( false );
+	}
+
+	github.request({
+		headers: {
+			Authorization: "token " + token
+		},
+		path: "/repos/jquery/foundation/contents/documents/" + src
+	}, function( error, file ) {
+		if ( error ) {
+			grunt.log.error( error );
+			return done( false );
+		}
+
+		grunt.file.write( dest, new Buffer( file.content, file.encoding ).toString( "utf8" ) );
+		grunt.log.writeln( "Copied " + src + " from foundation repo." );
+		done();
+	});
 });
 
 grunt.registerTask( "default", "lint" );

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "grunt-clean": "0.3.0",
     "grunt-html": "0.1.1",
     "grunt-wordpress": "1.0.7",
-    "grunt-jquery-content": "0.9.0"
+    "grunt-jquery-content": "0.9.0",
+    "github-request": "1.0.0"
   },
   "keywords": []
 }


### PR DESCRIPTION
This is a standalone task that isn't run during deploy. There are two reasons for this:

1) Contributors won't be able to run this task since it accesses a private repo.

2) The docs that get copied become pages, which are managed via git. We wouldn't want a deployment to create local changes.

The idea is that board members would be able to run this task after a document changes and commit the results. I implemented this with a token in a config file, but we could also prompt the user for their GitHub username and password. This just seemed easier.
