### PR TITLE
Members: Fix insecure content warnings

### DIFF
--- a/pages/members.html
+++ b/pages/members.html
@@ -25,23 +25,23 @@
 
 		<ul class="block-grid mobile four-up">
 			<li>
-				<img src="https://secure.gravatar.com/avatar/a9d4d2558b560b0ef168ced0f6c5198c?size=120" alt="">
+				<img src="https://gravatar.com/avatar/a9d4d2558b560b0ef168ced0f6c5198c?size=120" alt="">
 				<h3>Jörn Zaefferer</h3>
 			</li>
 			<li>
-				<img src="https://secure.gravatar.com/avatar/161a4cc619398bea1e1714036ed122cf?size=120" alt="">
+				<img src="https://gravatar.com/avatar/161a4cc619398bea1e1714036ed122cf?size=120" alt="">
 				<h3>Dave Methvin</h3>
 			</li>
 			<li>
-				<img src="https://secure.gravatar.com/avatar/911518c9eb1079cb417b06b78215414b?size=120" alt="">
+				<img src="https://gravatar.com/avatar/911518c9eb1079cb417b06b78215414b?size=120" alt="">
 				<h3>Kris Borchers</h3>
 			</li>
 			<li>
-				<img src="https://secure.gravatar.com/avatar/83fa9332d8b2d6449a40977b94ac6a6c?size=120" alt="">
+				<img src="https://gravatar.com/avatar/83fa9332d8b2d6449a40977b94ac6a6c?size=120" alt="">
 				<h3>TJ VanToll</h3>
 			</li>
 			<li>
-				<img src="https://secure.gravatar.com/avatar/ca7f5b3116ee570a2764b8cb113d0b42?size=120" alt="">
+				<img src="https://gravatar.com/avatar/ca7f5b3116ee570a2764b8cb113d0b42?size=120" alt="">
 				<h3>Krishan Taylor</h3>
 			</li>
 			<li>
@@ -49,7 +49,7 @@
 				<h3>Eric Ladd</h3>
 			</li>
 			<li>
-				<img src="https://secure.gravatar.com/avatar/cd9503474acf643669dba75c3fdc87f9?size=120" alt="">
+				<img src="https://gravatar.com/avatar/cd9503474acf643669dba75c3fdc87f9?size=120" alt="">
 				<h3>Isao Mishima</h3>
 			</li>
 			<li>
@@ -57,15 +57,15 @@
 				<h3>John Ragland</h3>
 			</li>
 			<li>
-				<img src="https://secure.gravatar.com/avatar/84271e67acf974b1159316184a0131d7?size=120" alt="">
+				<img src="https://gravatar.com/avatar/84271e67acf974b1159316184a0131d7?size=120" alt="">
 				<h3>George Diaz</h3>
 			</li>
 			<li>
-				<img src="https://secure.gravatar.com/avatar/1d2d86462361077fe0b7fbbc633683f2?size=120" alt="">
+				<img src="https://gravatar.com/avatar/1d2d86462361077fe0b7fbbc633683f2?size=120" alt="">
 				<h3>Jev Zelenkov</h3>
 			</li>
 			<li>
-				<img src="https://secure.gravatar.com/avatar/f30e97562e1ac7c8eacba8877f0ed07e?size=120" alt="">
+				<img src="https://gravatar.com/avatar/f30e97562e1ac7c8eacba8877f0ed07e?size=120" alt="">
 				<h3>Kelly Derrick</h3>
 			</li>
 			<li>
@@ -73,27 +73,27 @@
 				<h3>Ken Gladden</h3>
 			</li>
 			<li>
-				<img src="https://secure.gravatar.com/avatar/0f6923fc391653284355a60fb4974e86?size=120" alt="">
+				<img src="https://gravatar.com/avatar/0f6923fc391653284355a60fb4974e86?size=120" alt="">
 				<h3>Karl Swedberg</h3>
 			</li>
 			<li>
-				<img src="https://secure.gravatar.com/avatar/e8170d7574cd649bce2639e24737de88?size=120" alt="">
+				<img src="https://gravatar.com/avatar/e8170d7574cd649bce2639e24737de88?size=120" alt="">
 				<h3>Jasper de Groot</h3>
 			</li>
 			<li>
-				<img src="http://www.gravatar.com/avatar/f49efe3d86244e383d61ae9728502195?size=120" alt="">
+				<img src="https://gravatar.com/avatar/f49efe3d86244e383d61ae9728502195?size=120" alt="">
 				<h3>Justin Dorfman</h3>
 			</li>
 			<li>
-				<img src="http://www.gravatar.com/avatar/d37d78125c82f4d0e7ac42574aca22a4?size=120" alt="">
+				<img src="https://gravatar.com/avatar/d37d78125c82f4d0e7ac42574aca22a4?size=120" alt="">
 				<h3>Christopher Schmitt</h3>
 			</li>
 			<li>
-				<img src="http://www.gravatar.com/avatar/b2bef16d251e5dfe3be5e31182a822b6?size=120" alt="">
+				<img src="https://gravatar.com/avatar/b2bef16d251e5dfe3be5e31182a822b6?size=120" alt="">
 				<h3>Anne-Gaelle Colom</h3>
 			</li>
 			<li>
-				<img src="http://www.gravatar.com/avatar/35da631954825179143c86fa42a10954?size=120" alt="">
+				<img src="https://gravatar.com/avatar/35da631954825179143c86fa42a10954?size=120" alt="">
 				<h3>Scott González</h3>
 			</li>
 		</ul>


### PR DESCRIPTION
Follows-up 9e363b9, 9804c5e, a18cb1b.

Use HTTPS instead of HTTP for recently added Gravatar links.

While at it, also update old secure.gravatar.com references to plain https://gravatar.com.