### PR TITLE
Code of Conduct

### DIFF
--- a/pages/conduct.md
+++ b/pages/conduct.md
@@ -9,7 +9,7 @@ Diversity is one of our huge strengths, but it can also lead to communication is
 
 This isn’t an exhaustive list of things that you can’t do. Rather, take it in the spirit in which it’s intended - a guide to make it easier to enrich all of us and the technical communities in which we participate.
 
-This code of conduct applies to all spaces managed by the jQuery project or jQuery Foundation. This includes IRC, the mailing lists, the issue tracker, jQuery events, and any other forums created by the project team which the community uses for communication. In addition, violations of this code outside these spaces may affect a person's ability to participate within them.
+This code of conduct applies to all spaces managed by the jQuery Foundation and its projects. This includes IRC, the mailing lists, the issue tracker, jQuery events, and any other forums created by the project team which the community uses for communication. In addition, violations of this code outside these spaces may affect a person's ability to participate within them.
 
 If you believe someone is violating the code of conduct, we ask that you report it by emailing conduct@jquery.com. For more details please see our [Reporting Guidelines](https://jquery.org/conduct/reporting/)
 

--- a/pages/conduct.md
+++ b/pages/conduct.md
@@ -1,0 +1,40 @@
+<script>{
+	"title": "jQuery Foundation Code of Conduct",
+	"pageTemplate": "page-conduct.php"
+}</script>
+
+Like the technical community as a whole, the jQuery team and community is made up of a mixture of professionals and volunteers from all over the world, working on every aspect of the mission - including mentorship, teaching, and connecting people.
+
+Diversity is one of our huge strengths, but it can also lead to communication issues and unhappiness. To that end, we have a few ground rules that we ask people to adhere to. This code applies equally to founders, mentors and those seeking help and guidance.
+
+This isn’t an exhaustive list of things that you can’t do. Rather, take it in the spirit in which it’s intended - a guide to make it easier to enrich all of us and the technical communities in which we participate.
+
+This code of conduct applies to all spaces managed by the jQuery project or jQuery Foundation. This includes IRC, the mailing lists, the issue tracker, jQuery events, and any other forums created by the project team which the community uses for communication. In addition, violations of this code outside these spaces may affect a person's ability to participate within them.
+
+If you believe someone is violating the code of conduct, we ask that you report it by emailing conduct@jquery.com. For more details please see our [Reporting Guidelines](https://jquery.org/conduct/reporting/)
+
+* **Be friendly and patient.**
+
+* **Be welcoming.** We strive to be a community that welcomes and supports people of all backgrounds and identities. This includes, but is not limited to members of any race, ethnicity, culture, national origin, colour, immigration status, social and economic class, educational level, sex, sexual orientation, gender identity and expression, age, size, family status, political belief, religion, and mental and physical ability.
+
+* **Be considerate.** Your work will be used by other people, and you in turn will depend on the work of others. Any decision you take will affect users and colleagues, and you should take those consequences into account when making decisions. Remember that we're a world-wide community, so you might not be communicating in someone else's primary language.
+
+* **Be respectful.** Not all of us will agree all the time, but disagreement is no excuse for poor behavior and poor manners. We might all experience some frustration now and then, but we cannot allow that frustration to turn into a personal attack. It’s important to remember that a community where people feel uncomfortable or threatened is not a productive one. Members of the jQuery community should be respectful when dealing with other members as well as with people outside the jQuery community.
+
+* **Be careful in the words that you choose.** We are a community of professionals, and we conduct ourselves professionally. Be kind to others. Do not insult or put down other participants. Harassment and other exclusionary behavior aren't acceptable. This includes, but is not limited to:
+	* Violent threats or language directed against another person.
+	* Discriminatory jokes and language.
+	* Posting sexually explicit or violent material.
+	* Posting (or threatening to post) other people's personally identifying information ("doxing").
+	* Personal insults, especially those using racist or sexist terms.
+	* Unwelcome sexual attention.
+	* Advocating for, or encouraging, any of the above behavior.
+	* Repeated harassment of others. In general, if someone asks you to stop, then stop.
+
+* **When we disagree, try to understand why.** Disagreements, both social and technical, happen all the time and jQuery is no exception. It is important that we resolve disagreements and differing views constructively. Remember that we’re different. The strength of jQuery comes from its varied community, people from a wide range of backgrounds. Different people have different perspectives on issues. Being unable to understand why someone holds a viewpoint doesn’t mean that they’re wrong. Don’t forget that it is human to err and blaming each other doesn’t get us anywhere. Instead, focus on helping to resolve issues and learning from mistakes.
+
+Original text courtesy of the [Speak Up! project](http://speakup.io/coc.html) and [Django Project](https://www.djangoproject.com/conduct/).
+
+## Questions?
+
+If you have questions, please see the [FAQ](https://jquery.org/conduct/faq/). If that doesn't answer your questions, feel free to [contact us](mailto:conduct@jquery.com)

--- a/pages/conduct.md
+++ b/pages/conduct.md
@@ -18,7 +18,7 @@ We understand that we all have different levels of experience or knowledge in ma
 
 * **Be welcoming.** We strive to be a community that welcomes and supports people of all backgrounds and identities. This includes, but is not limited to members of any race, ethnicity, culture, national origin, color, immigration status, social and economic class, educational level, sex, sexual orientation, gender identity and expression, age, size, family status, political belief, religion, and mental and physical ability.
 
-* **Be considerate.** Your work will be used by other people, and you in turn will depend on the work of others. Any decision you take will affect users and colleagues, and you should take those consequences into account when making decisions. Remember that we're a world-wide community, so you might not be communicating in someone else's primary language.
+* **Be considerate.** Your work will be used by other people, and you in turn will depend on the work of others. Any decision you make will affect users and colleagues, and you should take those consequences into account when making decisions. Remember that we're a world-wide community, so you might not be communicating in someone else's primary language.
 
 * **Be respectful.** Not all of us will agree all the time, but disagreement is no excuse for poor behavior and poor manners. We might all experience some frustration now and then, but we cannot allow that frustration to turn into a personal attack. It’s important to remember that a community where people feel uncomfortable or threatened is not a productive one. Members of the jQuery community should be respectful when dealing with other members as well as with people outside the jQuery community.
 

--- a/pages/conduct.md
+++ b/pages/conduct.md
@@ -11,11 +11,11 @@ This isn’t an exhaustive list of things that you can’t do. Rather, take it i
 
 This code of conduct applies to all spaces managed by the jQuery Foundation and its projects. This includes IRC, the mailing lists, the issue tracker, jQuery events, and any other forums created by the project team which the community uses for communication. In addition, violations of this code outside these spaces may affect a person's ability to participate within them.
 
-If you believe someone is violating the code of conduct, we ask that you report it by emailing conduct@jquery.com. For more details please see our [Reporting Guidelines](https://jquery.org/conduct/reporting/)
+If you believe someone is violating the code of conduct, we ask that you report it by emailing conduct@jquery.org. For more details please see our [Reporting Guidelines](https://jquery.org/conduct/reporting/)
 
 * **Be friendly and patient.**
 
-* **Be welcoming.** We strive to be a community that welcomes and supports people of all backgrounds and identities. This includes, but is not limited to members of any race, ethnicity, culture, national origin, colour, immigration status, social and economic class, educational level, sex, sexual orientation, gender identity and expression, age, size, family status, political belief, religion, and mental and physical ability.
+* **Be welcoming.** We strive to be a community that welcomes and supports people of all backgrounds and identities. This includes, but is not limited to members of any race, ethnicity, culture, national origin, color, immigration status, social and economic class, educational level, sex, sexual orientation, gender identity and expression, age, size, family status, political belief, religion, and mental and physical ability.
 
 * **Be considerate.** Your work will be used by other people, and you in turn will depend on the work of others. Any decision you take will affect users and colleagues, and you should take those consequences into account when making decisions. Remember that we're a world-wide community, so you might not be communicating in someone else's primary language.
 
@@ -37,4 +37,4 @@ Original text courtesy of the [Speak Up! project](http://speakup.io/coc.html) an
 
 ## Questions?
 
-If you have questions, please see the [FAQ](https://jquery.org/conduct/faq/). If that doesn't answer your questions, feel free to [contact us](mailto:conduct@jquery.com)
+If you have questions, please see the [FAQ](https://jquery.org/conduct/faq/). If that doesn't answer your questions, feel free to [contact us](mailto:conduct@jquery.org)

--- a/pages/conduct.md
+++ b/pages/conduct.md
@@ -14,6 +14,7 @@ This code of conduct applies to all spaces managed by the jQuery Foundation and 
 If you believe someone is violating the code of conduct, we ask that you report it by emailing conduct@jquery.org. For more details please see our [Reporting Guidelines](https://jquery.org/conduct/reporting/)
 
 * **Be friendly and patient.**
+We understand that we all have different levels of experience or knowledge in many diverse fields, be it technical or non technical in nature. We also have areas of knowledge we are eager to expand, and we want to be a community where people can not only contribute, but feel comfortable to ask questions as well and learn along the way. If someone is wrong, or says something accidentally offensive, respond with patience and try to keep it polite and civil. Remember that we all were newbies at one point.
 
 * **Be welcoming.** We strive to be a community that welcomes and supports people of all backgrounds and identities. This includes, but is not limited to members of any race, ethnicity, culture, national origin, color, immigration status, social and economic class, educational level, sex, sexual orientation, gender identity and expression, age, size, family status, political belief, religion, and mental and physical ability.
 

--- a/pages/conduct/changes.md
+++ b/pages/conduct/changes.md
@@ -1,0 +1,24 @@
+<script>{
+  "title": "jQuery Foundation Code of Conduct - Changes",
+  "pageTemplate": "page-conduct.php"
+}</script>
+
+## Change control process
+
+We're (mostly) programmers, so we'll track changes to the code of conduct and associated documents the same way we track changes to code. All changes will proposed via a pull request to the [jquery.org repository on GitHub](http://github.com/jquery/jquery.org). Changes will be reviewed by the conduct committee first, and then sent to the jQuery Foundation, the jQuery development team, and the jQuery community for comment. We'll hold a comment period of at least one week, and then each group will vote on the change using its normal process (a board for the jQuery Foundation, [a core dev vote](https://docs.jquery.org/en/dev/internals/contributing/bugs-and-features/#how-we-make-decisions) for the core team). Approved changes will be merged, published, and noted below.
+
+This only applies to material changes; changes that don't effect the intent (typo fixes, re-wordings, etc.) can be made immediately.
+
+A complete list of changes can always be found [on GitHub](https://github.com/jquery/jquery.org/commits/master/pages/conduct.md); major changes and releases are summarized below.
+
+## Changelog
+
+<dl>
+
+<dt>TBD</dt>
+
+<dd>[Copied draft from Django Project](https://github.com/jquery/jquery.org/commit/).</dd>
+
+</dl>
+
+[Back to Top](#top)

--- a/pages/conduct/changes.md
+++ b/pages/conduct/changes.md
@@ -5,7 +5,7 @@
 
 ## Change control process
 
-We're (mostly) programmers, so we'll track changes to the code of conduct and associated documents the same way we track changes to code. All changes will proposed via a pull request to the [jquery.org repository on GitHub](http://github.com/jquery/jquery.org). Changes will be reviewed by the conduct committee first, and then sent to the jQuery Foundation, the jQuery development team, and the jQuery community for comment. We'll hold a comment period of at least one week, and then each group will vote on the change using its normal process (a board for the jQuery Foundation, [a core dev vote](https://docs.jquery.org/en/dev/internals/contributing/bugs-and-features/#how-we-make-decisions) for the core team). Approved changes will be merged, published, and noted below.
+We're (mostly) programmers, so we'll track changes to the code of conduct and associated documents the same way we track changes to code. All changes will be proposed via a pull request to the [jquery.org repository on GitHub](http://github.com/jquery/jquery.org). Changes will be reviewed by the conduct committee first, and then sent to the jQuery Foundation, the jQuery development team, and the jQuery community for comment. We'll hold a comment period of at least one week, and then each group will vote on the change using its normal process (a board for the jQuery Foundation, [a core dev vote](https://docs.jquery.org/en/dev/internals/contributing/bugs-and-features/#how-we-make-decisions) for the core team). Approved changes will be merged, published, and noted below.
 
 This only applies to material changes; changes that don't effect the intent (typo fixes, re-wordings, etc.) can be made immediately.
 

--- a/pages/conduct/changes.md
+++ b/pages/conduct/changes.md
@@ -15,9 +15,9 @@ A complete list of changes can always be found [on GitHub](https://github.com/jq
 
 <dl>
 
-<dt>TBD</dt>
+<dt>July 12, 2015</dt>
 
-<dd>[Copied draft from Django Project](https://github.com/jquery/jquery.org/commit/).</dd>
+<dd>[Copied draft from Django Project](https://github.com/jquery/jquery.org/commit/39594102137e72b62503b2d9a1233a521c2403c7).</dd>
 
 </dl>
 

--- a/pages/conduct/changes.md
+++ b/pages/conduct/changes.md
@@ -20,5 +20,3 @@ A complete list of changes can always be found [on GitHub](https://github.com/jq
 <dd>[Copied draft from Django Project](https://github.com/jquery/jquery.org/commit/39594102137e72b62503b2d9a1233a521c2403c7).</dd>
 
 </dl>
-
-[Back to Top](#top)

--- a/pages/conduct/committee.md
+++ b/pages/conduct/committee.md
@@ -9,8 +9,9 @@ Committee Members:
 
 * Chair: Corey Frang
 * Anne-Gaelle Colom
+* Sarah Frisk
 * John Resig
 * Adam Sontag
 
-You can contact [conduct@jquery.com](mailto:conduct@jquery.com). For more details please see the [Reporting Guidelines](https://jquery.org/conduct/reporting/).
+You can contact [conduct@jquery.org](mailto:conduct@jquery.org). For more details please see the [Reporting Guidelines](https://jquery.org/conduct/reporting/).
 

--- a/pages/conduct/committee.md
+++ b/pages/conduct/committee.md
@@ -1,0 +1,13 @@
+<script>{
+	"title": "jQuery Foundation Code of Conduct - Committee",
+	"pageTemplate": "page-conduct.php"
+}</script>
+
+The Code of Conduct Committee deals with violations in the [jQuery Code of Conduct](https://jquery.org/conduct/).
+
+Committee Members:
+
+* TBD
+
+You can contact [conduct@jquery.com](mailto:conduct@jquery.com). For more details please see the [Reporting Guidelines](https://jquery.org/conduct/reporting/).
+

--- a/pages/conduct/committee.md
+++ b/pages/conduct/committee.md
@@ -7,7 +7,10 @@ The Code of Conduct Committee deals with violations in the [jQuery Code of Condu
 
 Committee Members:
 
-* TBD
+* Chair: Corey Frang
+* Anne-Gaelle Colom
+* John Resig
+* Adam Sontag
 
 You can contact [conduct@jquery.com](mailto:conduct@jquery.com). For more details please see the [Reporting Guidelines](https://jquery.org/conduct/reporting/).
 

--- a/pages/conduct/enforcement-manual.md
+++ b/pages/conduct/enforcement-manual.md
@@ -7,7 +7,7 @@ This is the enforcement manual followed by jQuery's Code of Conduct Committee. I
 
 ### The Code of Conduct Committee
 
-All responses to reports of conduct violations will be managed by a [Code of Conduct Committee](https://jquery.org/conduct/comittee/) ("the committee").
+All responses to reports of conduct violations will be managed by a [Code of Conduct Committee](https://jquery.org/conduct/committee/) ("the committee").
 
 The jQuery Foundation's Board of Directors ("the board") will establish this committee, comprised of at least three members. One member will be designated chair of the group and will be responsible for all reports back to the board. The board will review membership on a regular basis.
 
@@ -34,11 +34,11 @@ If the act is ongoing (such as someone engaging in harassment in #jquery), or in
 
 If the incident involves physical danger, any member of the committee may -- and should -- act unilaterally to protect safety. This can include contacting law enforcement (or other local personnel) and speaking on behalf of the jQuery Foundation.
 
-In situations where an individual group member acts unilaterally, they must report their actions to the comittee for review within 24 hours.
+In situations where an individual group member acts unilaterally, they must report their actions to the committee for review within 24 hours.
 
 ### Resolutions
 
-The comittee must agree on a resolution by consensus. If the group cannot reach consensus and deadlocks for over a week, the group will turn the matter over to the board for resolution.
+The committee must agree on a resolution by consensus. If the group cannot reach consensus and deadlocks for over a week, the group will turn the matter over to the board for resolution.
 
 Possible responses may include:
 
@@ -49,12 +49,12 @@ Possible responses may include:
 *   A permanent or temporary ban from some or all jQuery spaces (mailing lists, IRC, etc.). The group will maintain records of all such bans so that they may be reviewed in the future, extended to new jQuery fora, or otherwise maintained.
 *   A request for a public or private apology. The chair will deliver this request. The group may, if it chooses, attach "strings" to this request: for example, the group may ask a violator to apologize in order to retain his or her membership on a mailing list.
 
-Once a resolution is agreed upon, but before it is enacted, the committee will contact the original reporter and any other affected parties and explain the proposed resolution. The comittee will ask if this resolution is acceptable, and must note feedback for the record. However, the committee is not required to act on this feedback.
+Once a resolution is agreed upon, but before it is enacted, the committee will contact the original reporter and any other affected parties and explain the proposed resolution. The committee will ask if this resolution is acceptable, and must note feedback for the record. However, the committee is not required to act on this feedback.
 
 Finally the committee will make a report for the jQuery Foundation Board (as well as the project teams in the event of an ongoing resolution, such as a ban).
 
-The comittee will never publicly discuss the issue; all public statements will be made by the jQuery Foundation Board.
+The committee will never publicly discuss the issue; all public statements will be made by the jQuery Foundation Board.
 
 ### Conflicts of Interest
 
-In the event of any conflict of interest a comittee member must immediately notify the other members, and recuse themselves if necessary.
+In the event of any conflict of interest a committee member must immediately notify the other members, and recuse themselves if necessary.

--- a/pages/conduct/enforcement-manual.md
+++ b/pages/conduct/enforcement-manual.md
@@ -19,10 +19,10 @@ See the [reporting guidelines](https://www.jquery.org/conduct/reporting/) for de
 
 The committee will then review the incident and determine, to the best of their ability:
 
-*   what happened
-*   whether this event constitutes a code of conduct violation
-*   who, if anyone, was the bad actor
-*   whether this is an ongoing situation, and there is a threat to anyone's physical safety
+*   What happened.
+*   Whether this event constitutes a Code of Conduct violation.
+*   Who, if anyone, was the bad actor.
+*   Whether this is an ongoing situation, and if there is a threat to anyone's physical safety.
 
 This information will be collected in writing, and whenever possible the group's deliberations will be recorded and retained (e.g. IRC transcripts, email discussions, or recorded voice conversations).
 

--- a/pages/conduct/enforcement-manual.md
+++ b/pages/conduct/enforcement-manual.md
@@ -26,35 +26,35 @@ The committee will then review the incident and determine, to the best of their 
 
 This information will be collected in writing, and whenever possible the group's deliberations will be recorded and retained (i.e. IRC transcripts, email discussions, recorded voice conversations, etc).
 
-The working group should aim to have a resolution agreed upon within one week. In the event that a resolution can't be determined in that time, the group will respond to the reporter(s) with an update and projected timeline for resolution.
+The committee should aim to have a resolution agreed upon within one week. In the event that a resolution can't be determined in that time, the group will respond to the reporter(s) with an update and projected timeline for resolution.
 
 ### Acting Unilaterally
 
-If the act is ongoing (such as someone engaging in harassment in #jquery), or involves a threat to anyone's safety (e.g. threats of violence), any working group member may act immediately (before reaching consensus) to end the situation. In ongoing situations, any member may at their discretion employ any of the tools available to the working group, including bans and blocks.
+If the act is ongoing (such as someone engaging in harassment in #jquery), or involves a threat to anyone's safety (e.g. threats of violence), any committee member or moderator may act immediately (before reaching consensus) to end the situation. In ongoing situations, any moderator may at their discretion employ any of the tools available to the committee, including bans and blocks.
 
-If the incident involves physical danger, any member of the working group may -- and should -- act unilaterally to protect safety. This can include contacting law enforcement (or other local personnel) and speaking on behalf of the jQuery Foundation.
+If the incident involves physical danger, any member of the committee may -- and should -- act unilaterally to protect safety. This can include contacting law enforcement (or other local personnel) and speaking on behalf of the jQuery Foundation.
 
-In situations where an individual group member acts unilaterally, they must report their actions to the working group for review within 24 hours.
+In situations where an individual group member acts unilaterally, they must report their actions to the comittee for review within 24 hours.
 
 ### Resolutions
 
-The working group must agree on a resolution by consensus. If the group cannot reach consensus and deadlocks for over a week, the group will turn the matter over to the board for resolution.
+The comittee must agree on a resolution by consensus. If the group cannot reach consensus and deadlocks for over a week, the group will turn the matter over to the board for resolution.
 
 Possible responses may include:
 
 *   Taking no further action (if we determine no violation occurred).
-*   A private reprimand from the working group to the individual(s) involved. In this case, the group chair will deliver that reprimand to the individual(s) over email, cc'ing the group.
+*   A private reprimand from the committee to the individual(s) involved. In this case, the group chair will deliver that reprimand to the individual(s) over email, cc'ing the group.
 *   A public reprimand. In this case, the group chair will deliver that reprimand in the same venue that the violation occurred (i.e. in IRC for an IRC violation; email for an email violation, etc.). The group may choose to publish this message elsewhere for posterity.
 *   An imposed vacation (i.e. asking someone to "take a week off" from a mailing list or IRC). The group chair will communicate this "vacation" to the individual(s). They'll be asked to take this vacation voluntarily, but if they don't agree then a temporary ban may be imposed to enforce this vacation.
 *   A permanent or temporary ban from some or all jQuery spaces (mailing lists, IRC, etc.). The group will maintain records of all such bans so that they may be reviewed in the future, extended to new jQuery fora, or otherwise maintained.
 *   A request for a public or private apology. The chair will deliver this request. The group may, if it chooses, attach "strings" to this request: for example, the group may ask a violator to apologize in order to retain his or her membership on a mailing list.
 
-Once a resolution is agreed upon, but before it is enacted, the working group will contact the original reporter and any other affected parties and explain the proposed resolution. The working group will ask if this resolution is acceptable, and must note feedback for the record. However, the working group is not required to act on this feedback.
+Once a resolution is agreed upon, but before it is enacted, the committee will contact the original reporter and any other affected parties and explain the proposed resolution. The comittee will ask if this resolution is acceptable, and must note feedback for the record. However, the committee is not required to act on this feedback.
 
-Finally the working group will make a report for the jQuery Foundation board (as well as the jQuery core team in the event of an ongoing resolution, such as a ban).
+Finally the committee will make a report for the jQuery Foundation Board (as well as the project teams in the event of an ongoing resolution, such as a ban).
 
-The working group will never publicly discuss the issue; all public statements will be made by the jQuery Foundation board.
+The comittee will never publicly discuss the issue; all public statements will be made by the jQuery Foundation Board.
 
 ### Conflicts of Interest
 
-In the event of any conflict of interest a working group member must immediately notify the other members, and recuse themselves if necessary.
+In the event of any conflict of interest a comittee member must immediately notify the other members, and recuse themselves if necessary.

--- a/pages/conduct/enforcement-manual.md
+++ b/pages/conduct/enforcement-manual.md
@@ -3,7 +3,7 @@
 	"pageTemplate": "page-conduct.php"
 }</script>
 
-This is the enforcement manual followed by jQuery's Code of Conduct Committee. It's used when we respond to an issue to make sure we're consistent and fair. It should be considered an internal document, but we're publishing it publicly in the interests of transparency.
+This is the enforcement manual followed by jQuery's Code of Conduct Committee. It's used when we respond to an issue to make sure we're consistent and fair. It should be considered an internal document, but we're publishing it publicly in the interest of transparency.
 
 ### The Code of Conduct Committee
 
@@ -13,7 +13,7 @@ The jQuery Foundation's Board of Directors ("the board") will establish this com
 
 ### How the committee will respond to reports
 
-When a report is sent to the committee they will immediately reply to the report to confirm receipt. This reply must be sent within 24 hours, and the group should strive to respond much quicker than that.
+When a report is sent to the committee they will immediately reply to the report to confirm receipt. This reply must be sent within 24 hours, and the group should strive to respond more quickly than that.
 
 See the [reporting guidelines](https://www.jquery.org/conduct/reporting/) for details of what reports should contain. If a report doesn't contain enough information, the committee will obtain all relevant data before acting. The committee is empowered to act on the jQuery Foundation's behalf in contacting any individuals involved to get a more complete account of events.
 
@@ -24,7 +24,7 @@ The committee will then review the incident and determine, to the best of their 
 *   who, if anyone, was the bad actor
 *   whether this is an ongoing situation, and there is a threat to anyone's physical safety
 
-This information will be collected in writing, and whenever possible the group's deliberations will be recorded and retained (i.e. IRC transcripts, email discussions, recorded voice conversations, etc).
+This information will be collected in writing, and whenever possible the group's deliberations will be recorded and retained (e.g. IRC transcripts, email discussions, or recorded voice conversations).
 
 The committee should aim to have a resolution agreed upon within one week. In the event that a resolution can't be determined in that time, the group will respond to the reporter(s) with an update and projected timeline for resolution.
 
@@ -44,9 +44,9 @@ Possible responses may include:
 
 *   Taking no further action (if we determine no violation occurred).
 *   A private reprimand from the committee to the individual(s) involved. In this case, the group chair will deliver that reprimand to the individual(s) over email, cc'ing the group.
-*   A public reprimand. In this case, the group chair will deliver that reprimand in the same venue that the violation occurred (i.e. in IRC for an IRC violation; email for an email violation, etc.). The group may choose to publish this message elsewhere for posterity.
-*   An imposed vacation (i.e. asking someone to "take a week off" from a mailing list or IRC). The group chair will communicate this "vacation" to the individual(s). They'll be asked to take this vacation voluntarily, but if they don't agree then a temporary ban may be imposed to enforce this vacation.
-*   A permanent or temporary ban from some or all jQuery spaces (mailing lists, IRC, etc.). The group will maintain records of all such bans so that they may be reviewed in the future, extended to new jQuery fora, or otherwise maintained.
+*   A public reprimand. In this case, the group chair will deliver that reprimand in the same venue that the violation occurred (e.g. in IRC for an IRC violation; email for an email violation). The group may choose to publish this message elsewhere for posterity.
+*   An imposed vacation (e.g. asking someone to "take a week off" from a mailing list or IRC). The group chair will communicate this "vacation" to the individual(s). They'll be asked to take this vacation voluntarily, but if they don't agree then a temporary ban may be imposed to enforce this vacation.
+*   A permanent or temporary ban from some or all jQuery spaces (including mailing lists and IRC). The group will maintain records of all such bans so that they may be reviewed in the future, extended to new jQuery fora, or otherwise maintained.
 *   A request for a public or private apology. The chair will deliver this request. The group may, if it chooses, attach "strings" to this request: for example, the group may ask a violator to apologize in order to retain his or her membership on a mailing list.
 
 Once a resolution is agreed upon, but before it is enacted, the committee will contact the original reporter and any other affected parties and explain the proposed resolution. The committee will ask if this resolution is acceptable, and must note feedback for the record. However, the committee is not required to act on this feedback.

--- a/pages/conduct/enforcement-manual.md
+++ b/pages/conduct/enforcement-manual.md
@@ -9,7 +9,7 @@ This is the enforcement manual followed by jQuery's Code of Conduct Committee. I
 
 All responses to reports of conduct violations will be managed by a [Code of Conduct Committee](https://jquery.org/conduct/comittee/) ("the committee").
 
-The jQuery Foundation's Board of Directors ("the board") will establish this committee, compromised of at least three members. One member will be designated chair of the group and will be responsible for all reports back to the board. The board will review membership on a regular basis.
+The jQuery Foundation's Board of Directors ("the board") will establish this committee, comprised of at least three members. One member will be designated chair of the group and will be responsible for all reports back to the board. The board will review membership on a regular basis.
 
 ### How the committee will respond to reports
 

--- a/pages/conduct/enforcement-manual.md
+++ b/pages/conduct/enforcement-manual.md
@@ -1,0 +1,60 @@
+<script>{
+	"title": "jQuery Foundation Code of Conduct - Enforcement Manual",
+	"pageTemplate": "page-conduct.php"
+}</script>
+
+This is the enforcement manual followed by jQuery's Code of Conduct Committee. It's used when we respond to an issue to make sure we're consistent and fair. It should be considered an internal document, but we're publishing it publicly in the interests of transparency.
+
+### The Code of Conduct Committee
+
+All responses to reports of conduct violations will be managed by a [Code of Conduct Committee](https://jquery.org/conduct/comittee/) ("the committee").
+
+The jQuery Foundation's Board of Directors ("the board") will establish this committee, compromised of at least three members. One member will be designated chair of the group and will be responsible for all reports back to the board. The board will review membership on a regular basis.
+
+### How the committee will respond to reports
+
+When a report is sent to the committee they will immediately reply to the report to confirm receipt. This reply must be sent within 24 hours, and the group should strive to respond much quicker than that.
+
+See the [reporting guidelines](https://www.jquery.org/conduct/reporting/) for details of what reports should contain. If a report doesn't contain enough information, the committee will obtain all relevant data before acting. The committee is empowered to act on the jQuery Foundation's behalf in contacting any individuals involved to get a more complete account of events.
+
+The committee will then review the incident and determine, to the best of their ability:
+
+*   what happened
+*   whether this event constitutes a code of conduct violation
+*   who, if anyone, was the bad actor
+*   whether this is an ongoing situation, and there is a threat to anyone's physical safety
+
+This information will be collected in writing, and whenever possible the group's deliberations will be recorded and retained (i.e. IRC transcripts, email discussions, recorded voice conversations, etc).
+
+The working group should aim to have a resolution agreed upon within one week. In the event that a resolution can't be determined in that time, the group will respond to the reporter(s) with an update and projected timeline for resolution.
+
+### Acting Unilaterally
+
+If the act is ongoing (such as someone engaging in harassment in #jquery), or involves a threat to anyone's safety (e.g. threats of violence), any working group member may act immediately (before reaching consensus) to end the situation. In ongoing situations, any member may at their discretion employ any of the tools available to the working group, including bans and blocks.
+
+If the incident involves physical danger, any member of the working group may -- and should -- act unilaterally to protect safety. This can include contacting law enforcement (or other local personnel) and speaking on behalf of the jQuery Foundation.
+
+In situations where an individual group member acts unilaterally, they must report their actions to the working group for review within 24 hours.
+
+### Resolutions
+
+The working group must agree on a resolution by consensus. If the group cannot reach consensus and deadlocks for over a week, the group will turn the matter over to the board for resolution.
+
+Possible responses may include:
+
+*   Taking no further action (if we determine no violation occurred).
+*   A private reprimand from the working group to the individual(s) involved. In this case, the group chair will deliver that reprimand to the individual(s) over email, cc'ing the group.
+*   A public reprimand. In this case, the group chair will deliver that reprimand in the same venue that the violation occurred (i.e. in IRC for an IRC violation; email for an email violation, etc.). The group may choose to publish this message elsewhere for posterity.
+*   An imposed vacation (i.e. asking someone to "take a week off" from a mailing list or IRC). The group chair will communicate this "vacation" to the individual(s). They'll be asked to take this vacation voluntarily, but if they don't agree then a temporary ban may be imposed to enforce this vacation.
+*   A permanent or temporary ban from some or all jQuery spaces (mailing lists, IRC, etc.). The group will maintain records of all such bans so that they may be reviewed in the future, extended to new jQuery fora, or otherwise maintained.
+*   A request for a public or private apology. The chair will deliver this request. The group may, if it chooses, attach "strings" to this request: for example, the group may ask a violator to apologize in order to retain his or her membership on a mailing list.
+
+Once a resolution is agreed upon, but before it is enacted, the working group will contact the original reporter and any other affected parties and explain the proposed resolution. The working group will ask if this resolution is acceptable, and must note feedback for the record. However, the working group is not required to act on this feedback.
+
+Finally the working group will make a report for the jQuery Foundation board (as well as the jQuery core team in the event of an ongoing resolution, such as a ban).
+
+The working group will never publicly discuss the issue; all public statements will be made by the jQuery Foundation board.
+
+### Conflicts of Interest
+
+In the event of any conflict of interest a working group member must immediately notify the other members, and recuse themselves if necessary.

--- a/pages/conduct/faq.md
+++ b/pages/conduct/faq.md
@@ -13,13 +13,13 @@ We know that the jQuery community is open, friendly, and welcoming. We want to m
 
 ### What does it mean to "adopt" a Code of Conduct?
 
-For the most part, we don't think it means large changes. We think that the text does a really good job describing the way the jQuery community already conducts itself. We expect that most people will simple continue to behave in the awesome way they have for years.
+For the most part, we don't think it means large changes. We think that the text does a really good job describing the way the jQuery community already conducts itself. We expect that most people will simply continue to behave in the awesome way they have for years.
 
-However, we do expect that people will abide by the spirit and words of the CoC when in "official" jQuery spaces. This code has been adopted by both the jQuery core team and by the jQuery Software Foundation. That means that it'll apply both in community spaces _and_ at jQuery Foundation events.
+However, we do expect that people will abide by the spirit and words of the CoC when in "official" jQuery spaces. This code has been adopted by both the jQuery core team and by the jQuery Foundation. That means that it'll apply both in community spaces _and_ at jQuery Foundation events.
 
 In practice, this means the various jQuery IRC channels (<tt>#jquery</tt>, <tt>#jquery-dev</tt>, etc.), bug tracking and code review tools, and "official" jQuery events such as sprints. In addition, violations of this code outside these spaces may affect a person's ability to participate within them.
 
-### What about events funded by the jQuery Software Foundation?
+### What about events funded by the jQuery Foundation?
 
 This Code of Conduct also covers any events that the jQuery Foundation funds. However, events funded by the jQuery Foundation already [require a code of conduct](https://www.jquery.org/conduct/). Isn't this redundant?
 

--- a/pages/conduct/faq.md
+++ b/pages/conduct/faq.md
@@ -3,7 +3,7 @@
 	"pageTemplate": "page-conduct.php"
 }</script>
 
-This FAQ attempts to address common questions and concerns around the jQuery community's [Code of Conduct](https://www.jquery.org/conduct/). If you still have questions after reading it, please feel free to [contact us](mailto:conduct@jquery.com).
+This FAQ attempts to address common questions and concerns around the jQuery community's [Code of Conduct](https://www.jquery.org/conduct/). If you still have questions after reading it, please feel free to [contact us](mailto:conduct@jquery.org).
 
 ### Why have you adopted a Code of Conduct?
 
@@ -33,7 +33,7 @@ So the jQuery Foundation will require that all events it funds have some sort of
 
 ### What happens if someone violates the Code of Conduct?
 
-Our intent is that the anyone in the community can stand up for this Code, and direct people who're unaware to this document. If that doesn't work, or if you need more help, you can contact [conduct@jquery.com](mailto:conduct@jquery.com). For more details please see our [Reporting Guidelines](https://www.jquery.org/conduct/reporting/)
+Our intent is that the anyone in the community can stand up for this Code, and direct people who're unaware to this document. If that doesn't work, or if you need more help, you can contact [conduct@jquery.org](mailto:conduct@jquery.org). For more details please see our [Reporting Guidelines](https://www.jquery.org/conduct/reporting/)
 
 ### Why do we need a Code of Conduct? Everyone knows not to be a jerk.
 

--- a/pages/conduct/faq.md
+++ b/pages/conduct/faq.md
@@ -1,0 +1,46 @@
+<script>{
+	"title": "jQuery Foundation Code of Conduct - FAQ",
+	"pageTemplate": "page-conduct.php"
+}</script>
+
+This FAQ attempts to address common questions and concerns around the jQuery community's [Code of Conduct](https://www.jquery.org/conduct/). If you still have questions after reading it, please feel free to [contact us](mailto:conduct@jquery.com).
+
+### Why have you adopted a Code of Conduct?
+
+We think the jQuery community is awesome. If you're familiar with the jQuery community, you'll probably notice that the Code basically matches what we already do. Think of this as documentation: we're taking implicit expectations about behavior and making them explicit.
+
+We know that the jQuery community is open, friendly, and welcoming. We want to make sure everyone else knows it too.
+
+### What does it mean to "adopt" a Code of Conduct?
+
+For the most part, we don't think it means large changes. We think that the text does a really good job describing the way the jQuery community already conducts itself. We expect that most people will simple continue to behave in the awesome way they have for years.
+
+However, we do expect that people will abide by the spirit and words of the CoC when in "official" jQuery spaces. This code has been adopted by both the jQuery core team and by the jQuery Software Foundation. That means that it'll apply both in community spaces _and_ at jQuery Foundation events.
+
+In practice, this means the various jQuery IRC channels (<tt>#jquery</tt>, <tt>#jquery-dev</tt>, etc.), bug tracking and code review tools, and "official" jQuery events such as sprints. In addition, violations of this code outside these spaces may affect a person's ability to participate within them.
+
+### What about events funded by the jQuery Software Foundation?
+
+This Code of Conduct also covers any events that the jQuery Foundation funds. However, events funded by the jQuery Foundation already [require a code of conduct](https://www.jquery.org/conduct/). Isn't this redundant?
+
+No: there's a difference between the two, and they're complementary.
+
+This Code of Conduct is all about how we interact as a community. It's about saying that the jQuery community will be open, friendly, and welcoming. The core issue is about ensuring the conversations we have are productive and inviting for all.
+
+Real-life events, however, require a bit more care. The jQuery Foundation wants to be sure that any events it funds have policies and procedures in place for handling harassment. It's especially important to us that real-life events take steps to protect the physical and mental security of their participants.
+
+So the jQuery Foundation will require that any events it funds have some sort of anti- harassment policy in place. The jQuery Foundation thinks the [Ada Initiative's template](http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Policy) is pretty good, but we're open to alternatives.
+
+### What happens if someone violates the Code of Conduct?
+
+Our intent is that the anyone in the community can stand up for this code, and direct people who're unaware to this document. If that doesn't work, or if you need more help, you can contact [conduct@jquery.com](mailto:conduct@jquery.com). For more details please see our [Reporting Guidelines](https://www.jquery.org/conduct/reporting/)
+
+### Why do we need a Code of Conduct? Everyone knows not to be a jerk.
+
+Sadly, not everyone knows this.
+
+However, even if everyone was kind, everyone was compassionate, and everyone was familiar with codes of conduct it would still be incumbent upon our community to publish our own. Maintaining a code of conduct forces us to consider and articulate what kind of community we want to be, and serves as a constant reminder to put our best foot forward. But most importantly, it serves as a signpost to people looking to join our community that we feel these values are important.
+
+### This is censorship! I have the right to say whatever I want!
+
+You do -- in _your_ space. If you'd like to hang out in _our_ spaces (as clarified above), we have some simple guidelines to follow. If you want to, for example, form a group where jQuery is discussed using language inappropriate for general channels then nobody's stopping you. We respect your right to establish whatever codes of conduct you want in the spaces that belong to you. Please honor this Code of Conduct in our spaces.

--- a/pages/conduct/faq.md
+++ b/pages/conduct/faq.md
@@ -29,17 +29,17 @@ This Code of Conduct is all about how we interact as a community. It's about say
 
 Real-life events, however, require a bit more care. The jQuery Foundation wants to be sure that any events it funds have policies and procedures in place for handling harassment. It's especially important to us that real-life events take steps to protect the physical and mental security of their participants.
 
-So the jQuery Foundation will require that any events it funds have some sort of anti- harassment policy in place. The jQuery Foundation thinks the [Ada Initiative's template](http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Policy) is pretty good, but we're open to alternatives.
+So the jQuery Foundation will require that all events it funds have some sort of anti- harassment policy in place. The jQuery Foundation thinks the [Ada Initiative's template](http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Policy) is pretty good, but we're open to alternatives.
 
 ### What happens if someone violates the Code of Conduct?
 
-Our intent is that the anyone in the community can stand up for this code, and direct people who're unaware to this document. If that doesn't work, or if you need more help, you can contact [conduct@jquery.com](mailto:conduct@jquery.com). For more details please see our [Reporting Guidelines](https://www.jquery.org/conduct/reporting/)
+Our intent is that the anyone in the community can stand up for this Code, and direct people who're unaware to this document. If that doesn't work, or if you need more help, you can contact [conduct@jquery.com](mailto:conduct@jquery.com). For more details please see our [Reporting Guidelines](https://www.jquery.org/conduct/reporting/)
 
 ### Why do we need a Code of Conduct? Everyone knows not to be a jerk.
 
 Sadly, not everyone knows this.
 
-However, even if everyone was kind, everyone was compassionate, and everyone was familiar with codes of conduct it would still be incumbent upon our community to publish our own. Maintaining a code of conduct forces us to consider and articulate what kind of community we want to be, and serves as a constant reminder to put our best foot forward. But most importantly, it serves as a signpost to people looking to join our community that we feel these values are important.
+However, even if everyone were kind, compassionate, and familiar with codes of conduct, it would still be incumbent upon our community to publish our own. Maintaining a code of conduct forces us to consider and articulate what kind of community we want to be, and serves as a constant reminder to put our best foot forward. But most importantly, it serves as a signpost to people looking to join our community that we feel these values are important.
 
 ### This is censorship! I have the right to say whatever I want!
 

--- a/pages/conduct/faq.md
+++ b/pages/conduct/faq.md
@@ -17,7 +17,7 @@ For the most part, we don't think it means large changes. We think that the text
 
 However, we do expect that people will abide by the spirit and words of the CoC when in "official" jQuery spaces. This code has been adopted by both the jQuery core team and by the jQuery Foundation. That means that it'll apply both in community spaces _and_ at jQuery Foundation events.
 
-In practice, this means the various jQuery IRC channels (<tt>#jquery</tt>, <tt>#jquery-dev</tt>, etc.), bug tracking and code review tools, and "official" jQuery events such as sprints. In addition, violations of this code outside these spaces may affect a person's ability to participate within them.
+In practice, this means the various jQuery IRC channels (#jquery, #jquery-dev, etc.), bug tracking and code review tools, and "official" jQuery events such as sprints. In addition, violations of this code outside these spaces may affect a person's ability to participate within them.
 
 ### What about events funded by the jQuery Foundation?
 

--- a/pages/conduct/reporting.md
+++ b/pages/conduct/reporting.md
@@ -9,7 +9,7 @@ If you believe someone is violating the code of conduct we ask that you report i
 
 In your report please include:
 
-*   Your contact info (so we can get in touch with you if we need to follow up)
+*   Your contact info (so we can get in touch with you if we need to follow up).
 *   Names (real, nicknames, or pseudonyms) of any individuals involved. If there were other witnesses besides you, please try to include them as well.
 *   When and where the incident occurred. Please be as specific as possible.
 *   Your account of what occurred. If there is a publicly available record (e.g. a mailing list archive or a public IRC logger) please include a link.  Screenshots can be useful in the case something is edited or deleted before action is taken.
@@ -19,7 +19,7 @@ In your report please include:
 
 ### What happens after you file a report?
 
-You will receive an email from the jQuery Foundation Code of Conduct Working Group acknowledging receipt immediately. We promise to acknowledge receipt within 24 hours (and will aim for much quicker than that).
+You will receive an email from the jQuery Foundation Code of Conduct Working Group acknowledging receipt immediately. We promise to acknowledge receipt within 24 hours (and will aim to do so more quickly than that).
 
 Members of the committee will immediately meet to review the incident and determine:
 
@@ -30,13 +30,13 @@ Members of the committee will immediately meet to review the incident and determ
 
 If this is determined to be an ongoing incident or a threat to physical safety, the immediate priority will be to protect everyone involved. This means we may delay an "official" response until we believe that the situation has ended and that everyone is physically safe.
 
-Once the committee has a complete account of the events they will make a decision as to how to response. Responses may include:
+Once the committee has a complete account of the events they will make a decision as to how to respond. Responses may include:
 
 *   Nothing (if we determine no violation occurred).
 *   A private reprimand from the committee to the individual(s) involved.
 *   A public reprimand.
-*   An imposed vacation (i.e. asking someone to "take a week off" from a mailing list or IRC).
-*   A permanent or temporary ban from some or all jQuery spaces (mailing lists, IRC, etc.)
+*   An imposed vacation (e.g. asking someone to "take a week off" from a mailing list or IRC).
+*   A permanent or temporary ban from some or all jQuery spaces (including online spaces such as mailing lists and IRC).
 *   A request for a public or private apology.
 
 We'll respond within one week to the person who filed the report with either a resolution or an explanation of why the situation is not yet resolved.

--- a/pages/conduct/reporting.md
+++ b/pages/conduct/reporting.md
@@ -1,0 +1,50 @@
+<script>{
+	"title": "jQuery Foundation Code of Conduct - Reporting Guide",
+	"pageTemplate": "page-conduct.php"
+}</script>
+
+If you believe someone is violating the code of conduct we ask that you report it to the jQuery Foundation by emailing [conduct@jquery.com](mailto:conduct@jquery.com). **All reports will be kept confidential.** In some cases we may determine that a public statement will need to be made. If that's the case, the identities of all victims and reporters will remain confidential unless those individuals instruct us otherwise.
+
+**If you believe anyone is in physical danger, please notify appropriate law enforcement first.** If you are unsure what law enforcement agency is appropriate, please include this in your report and we will attempt to notify them.
+
+In your report please include:
+
+*   Your contact info (so we can get in touch with you if we need to follow up)
+*   Names (real, nicknames, or pseudonyms) of any individuals involved. If there were other witnesses besides you, please try to include them as well.
+*   When and where the incident occurred. Please be as specific as possible.
+*   Your account of what occurred. If there is a publicly available record (e.g. a mailing list archive or a public IRC logger) please include a link.
+*   Any extra context you believe existed for the incident.
+*   If you believe this incident is ongoing.
+*   Any other information you believe we should have.
+
+### What happens after you file a report?
+
+You will receive an email from the jQuery Foundation Code of Conduct Working Group acknowledging receipt immediately. We promise to acknowledge receipt within 24 hours (and will aim for much quicker than that).
+
+The working group will immediately meet to review the incident and determine:
+
+*   What happened.
+*   Whether this event constitutes a code of conduct violation.
+*   Who the bad actor was.
+*   Whether this is an ongoing situation, or if there is a threat to anyone's physical safety.
+
+If this is determined to be an ongoing incident or a threat to physical safety, the working groups' immediate priority will be to protect everyone involved. This means we may delay an "official" response until we believe that the situation has ended and that everyone is physically safe.
+
+Once the working group has a complete account of the events they will make a decision as to how to response. Responses may include:
+
+*   Nothing (if we determine no violation occurred).
+*   A private reprimand from the working group to the individual(s) involved.
+*   A public reprimand.
+*   An imposed vacation (i.e. asking someone to "take a week off" from a mailing list or IRC).
+*   A permanent or temporary ban from some or all jQuery spaces (mailing lists, IRC, etc.)
+*   A request for a public or private apology.
+
+We'll respond within one week to the person who filed the report with either a resolution or an explanation of why the situation is not yet resolved.
+
+Once we've determined our final action, we'll contact the original reporter to let them know what action (if any) we'll be taking. We'll take into account feedback from the reporter on the appropriateness of our response, but we don't guarantee we'll act on it.
+
+Finally, the Working Group will make a report on the situation to the jQuery Foundation board. The board may choose to a public report of the incident.
+
+### Appealing
+
+Only permanent resolutions (such as bans) may be appealed. To appeal a decision of the working group, contact the jQuery Foundation Board at [foundation@jquery.com](mailto:foundation@jquery.com) with your appeal and the jQuery Foundation board will review the case.

--- a/pages/conduct/reporting.md
+++ b/pages/conduct/reporting.md
@@ -3,7 +3,7 @@
 	"pageTemplate": "page-conduct.php"
 }</script>
 
-If you believe someone is violating the code of conduct we ask that you report it to the jQuery Foundation by emailing [conduct@jquery.com](mailto:conduct@jquery.com). **All reports will be kept confidential.** In some cases we may determine that a public statement will need to be made. If that's the case, the identities of all victims and reporters will remain confidential unless those individuals instruct us otherwise.
+If you believe someone is violating the code of conduct we ask that you report it to the jQuery Foundation by emailing [conduct@jquery.org](mailto:conduct@jquery.org). **All reports will be kept confidential.** In some cases we may determine that a public statement will need to be made. If that's the case, the identities of all victims and reporters will remain confidential unless those individuals instruct us otherwise.
 
 **If you believe anyone is in physical danger, please notify appropriate law enforcement first.** If you are unsure what law enforcement agency is appropriate, please include this in your report and we will attempt to notify them.
 
@@ -23,4 +23,4 @@ Reports will receive urgent and immediate attention from the Code of Conduct Com
 
 ### Appealing
 
-Only permanent resolutions (such as bans) may be appealed. To appeal a decision of the committee, contact the jQuery Foundation President and Executive Director at [executive@jquery.com](mailto:executive@jquery.com) with your appeal and they will review the case.
+Only permanent resolutions (such as bans) may be appealed. To appeal a decision of the committee, contact the jQuery Foundation President and Executive Director at [executive@jquery.org](mailto:executive@jquery.org) with your appeal and they will review the case.

--- a/pages/conduct/reporting.md
+++ b/pages/conduct/reporting.md
@@ -21,19 +21,19 @@ In your report please include:
 
 You will receive an email from the jQuery Foundation Code of Conduct Working Group acknowledging receipt immediately. We promise to acknowledge receipt within 24 hours (and will aim for much quicker than that).
 
-The working group will immediately meet to review the incident and determine:
+Members of the committee will immediately meet to review the incident and determine:
 
 *   What happened.
 *   Whether this event constitutes a code of conduct violation.
 *   Who the bad actor was.
 *   Whether this is an ongoing situation, or if there is a threat to anyone's physical safety.
 
-If this is determined to be an ongoing incident or a threat to physical safety, the working groups' immediate priority will be to protect everyone involved. This means we may delay an "official" response until we believe that the situation has ended and that everyone is physically safe.
+If this is determined to be an ongoing incident or a threat to physical safety, the immediate priority will be to protect everyone involved. This means we may delay an "official" response until we believe that the situation has ended and that everyone is physically safe.
 
-Once the working group has a complete account of the events they will make a decision as to how to response. Responses may include:
+Once the committee has a complete account of the events they will make a decision as to how to response. Responses may include:
 
 *   Nothing (if we determine no violation occurred).
-*   A private reprimand from the working group to the individual(s) involved.
+*   A private reprimand from the committee to the individual(s) involved.
 *   A public reprimand.
 *   An imposed vacation (i.e. asking someone to "take a week off" from a mailing list or IRC).
 *   A permanent or temporary ban from some or all jQuery spaces (mailing lists, IRC, etc.)
@@ -47,4 +47,4 @@ Finally, the Working Group will make a report on the situation to the jQuery Fou
 
 ### Appealing
 
-Only permanent resolutions (such as bans) may be appealed. To appeal a decision of the working group, contact the jQuery Foundation Board at [foundation@jquery.com](mailto:foundation@jquery.com) with your appeal and the jQuery Foundation board will review the case.
+Only permanent resolutions (such as bans) may be appealed. To appeal a decision of the committee, contact the jQuery Foundation President and Executive Director at [executive@jquery.com](mailto:executive@jquery.com) with your appeal and they will review the case.

--- a/pages/conduct/reporting.md
+++ b/pages/conduct/reporting.md
@@ -19,31 +19,7 @@ In your report please include:
 
 ### What happens after you file a report?
 
-You will receive an email from the jQuery Foundation Code of Conduct Working Group acknowledging receipt immediately. We promise to acknowledge receipt within 24 hours (and will aim to do so more quickly than that).
-
-Members of the committee will immediately meet to review the incident and determine:
-
-*   What happened.
-*   Whether this event constitutes a code of conduct violation.
-*   Who the bad actor was.
-*   Whether this is an ongoing situation, or if there is a threat to anyone's physical safety.
-
-If this is determined to be an ongoing incident or a threat to physical safety, the immediate priority will be to protect everyone involved. This means we may delay an "official" response until we believe that the situation has ended and that everyone is physically safe.
-
-Once the committee has a complete account of the events they will make a decision as to how to respond. Responses may include:
-
-*   Nothing (if we determine no violation occurred).
-*   A private reprimand from the committee to the individual(s) involved.
-*   A public reprimand.
-*   An imposed vacation (e.g. asking someone to "take a week off" from a mailing list or IRC).
-*   A permanent or temporary ban from some or all jQuery spaces (including online spaces such as mailing lists and IRC).
-*   A request for a public or private apology.
-
-We'll respond within one week to the person who filed the report with either a resolution or an explanation of why the situation is not yet resolved.
-
-Once we've determined our final action, we'll contact the original reporter to let them know what action (if any) we'll be taking. We'll take into account feedback from the reporter on the appropriateness of our response, but we don't guarantee we'll act on it.
-
-Finally, the Working Group will make a report on the situation to the jQuery Foundation board. The board may choose to a public report of the incident.
+Reports will receive urgent and immediate attention from the Code of Conduct Committee. Please refer to the [Enforcement Manual](https://jquery.org/conduct/enforcement-manual) for the complete information on how reports will be processed. Though normally considered an internal document, it has been published in full in the interest of transparency.
 
 ### Appealing
 

--- a/pages/conduct/reporting.md
+++ b/pages/conduct/reporting.md
@@ -12,7 +12,7 @@ In your report please include:
 *   Your contact info (so we can get in touch with you if we need to follow up)
 *   Names (real, nicknames, or pseudonyms) of any individuals involved. If there were other witnesses besides you, please try to include them as well.
 *   When and where the incident occurred. Please be as specific as possible.
-*   Your account of what occurred. If there is a publicly available record (e.g. a mailing list archive or a public IRC logger) please include a link.
+*   Your account of what occurred. If there is a publicly available record (e.g. a mailing list archive or a public IRC logger) please include a link.  Screenshots can be useful in the case something is edited or deleted before action is taken.
 *   Any extra context you believe existed for the incident.
 *   If you believe this incident is ongoing.
 *   Any other information you believe we should have.


### PR DESCRIPTION
Would close #104 

* [x] Requires https://github.com/jquery/jquery-wp-content/pull/367
* [x] Requires Conduct committee
* [x] Requires conduct@jquery.org e-mail
* [x] Requires jQuery Board Approval
* [x] Requires jQuery Developer Leads Approval
* [x] Requires foundation@jquery.org or similar email for public to reach Foundation Board for appeals

Please comment, suggest changes, etc.  This is a very quick copy/replace Django with jQuery to start with from [Djano Project's CoC](djangoproject.com/conduct/)
