### PR TITLE
Build: import redirects from infrastructure repo

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,6 @@
   "dependencies": {
     "github-request": "1.0.0",
     "grunt": "0.4.5",
-    "grunt-jquery-content": "2.0.0"
+    "grunt-jquery-content": "2.3.0"
   }
 }

--- a/redirects.json
+++ b/redirects.json
@@ -1,0 +1,8 @@
+{
+	"/sponsors/": "/members/",
+	"/about/": "/",
+	"/meeting/": "http://meetings.jquery.org",
+	"/meetings/": "http://meetings.jquery.org",
+	"/updates/": "http://meetings.jquery.org",
+	"/feed/": "http://meetings.jquery.org/feed"
+}


### PR DESCRIPTION
Possible as of grunt-jquery-content [2.3.0](https://github.com/jquery/grunt-jquery-content/commit/81579ec2e3db6327969f0f7cfcaab2b6afedec11), and now we want to port all redirects from the nginx configs to the site repos.

Ref https://github.com/jquery/infrastructure/blob/puppet-master/modules/jquery/manifests/wp/jqueryorg.pp#L15-19

@gnarf Can you review this? Thanks.