### PR TITLE
Index: remove unnecessary banner

### DIFF
--- a/pages/index.html
+++ b/pages/index.html
@@ -10,9 +10,6 @@
 	}
 </script>
 
-<div id="banner-secondary" class="large-banner">
-</div>
-
 <div class="sub-banner">
 	<p>Supporting the advancement of the web through JavaScript</p>
 </div>


### PR DESCRIPTION
Hello everyone!

In addition for jquery/jquery-wp-content#388 I deleted empty banner in `index.html`, because it's unnecessary.

Ref: jquery/jquery-wp-content#373
