### PR TITLE
Change Kevin Partington's gravatar URL

### DIFF
--- a/pages/team.html
+++ b/pages/team.html
@@ -236,7 +236,7 @@
 		<h3>Content</h3>
 	</li>
 	<li>
-		<img src="https://secure.gravatar.com/avatar/8be9ababd5134fe0d57e75680a28fdea?size=120" alt="">
+		<img src="https://secure.gravatar.com/avatar/c4963255021ac9ac790f7ac1f3e9f11c?size=120" alt="">
 		<h2>Kevin Partington</h2>
 		<h3>ESLint | QUnit</h3>
 	</li>


### PR DESCRIPTION
I was tweaking my Gravatar settings and somehow got a different e-mail address hash. Oops! At any rate, with this change, the Gravatar should more or less match my GitHub profile picture (although cropped differently).

No immediate rush to merge this from my perspective-- I don't mind the current picture. Please just merge when convenient.