### PR TITLE
Minor grammatical cleanup in projects/join.html

### DIFF
--- a/pages/projects/join.html
+++ b/pages/projects/join.html
@@ -19,13 +19,13 @@
 		<p>For years, the jQuery Foundation has supported the development and growth of projects like jQuery, Dojo, Esprima, lo-dash, and Grunt.</p>
 		<p>We strive to help each Foundation project succeed with its goals, make open source accessible to everyone, and encourage cross-project collaboration. Each project has different needs, so please <a href="mailto:projects@jquery.org">contact us</a> and we can discuss what the Foundation can do to assist your project community. Typically we help projects with some or all of:</p>
 		<ul>
-			<li><b>Ecosystem and community development:</b> To grow and thrive, a successful project needs a contributors for code, documentation, bug triage, and support. We can help to build those communities.</li>
+			<li><b>Ecosystem and community development:</b> To grow and thrive, a successful project needs contributors for code, documentation, bug triage, and support. We can help to build those communities.</li>
 			<li><b>Open source integrity, licensing, and IP:</b> We manage the Contributor License Agreement (CLA) process and monitor licensing of project trademarks.</li>
-			<li><b>Marketing and events:</b> We can host or license events to spread the word about its projects and help developers to use them better. We also host events to recruit new contributors to open source projects.</li>
+			<li><b>Marketing and events:</b> We can host or license events to spread the word about our projects and help developers to use them better. We also host events to recruit new contributors to open source projects.</li>
 			<li><b>Sponsorship and funding:</b> The Foundation can help to find sponsors for project initiatives and can fund project proposals that meet critical community needs.</li>
-			<li><b>Collaboration with projects:</b> As part of its commitment to open source, the Foundation is dedicated to having the JavaScript community collaborate on common goals. We can provide introductions and facilitiate meetings to encourage that collaboration.</li>
+			<li><b>Collaboration with projects:</b> As part of our commitment to open source, the Foundation is dedicated to having the JavaScript community collaborate on common goals. We can provide introductions and facilitiate meetings to encourage that collaboration.</li>
 			<li><b>Access to standards bodies and browser vendors:</b> The Foundation is a member of the ECMA TC39 (JavaScript) and W3C organizations, and we maintain close ties with browser vendors. Projects have the opportunity to have their voices heard in these groups.</li>
-			<li><b>Operations and infrastructure:</b> We can host project home pages in its web infrastructure, deliver files through its CDN, and provide testing infrastructure. </li>
+			<li><b>Operations and infrastructure:</b> We can host project home pages in our web infrastructure, deliver files through our CDN, and provide testing infrastructure.</li>
 		</ul>
 	</div>
 </div>


### PR DESCRIPTION
Removed an "a" that preceded a plural noun. Also replaced some instances of "its" (as in, "the Foundation's") with "our" to be consistent with first-person plural used elsewhere.

Some of the "its" to "our" replacements may not be desired (only a few were actually needed for parallelism reasons). If anyone wants me to revert some of these, let me know.

Of course, if we would rather just leave this page as is, feel free to close this. :-)