### PR TITLE
License.md - Update to work with JSF policies

### DIFF
--- a/pages/license.md
+++ b/pages/license.md
@@ -2,22 +2,26 @@
 	"title": "License"
 }</script>
 
+**Note:** For the purposes of this document, the term "Project" will refer to any [JS Foundation](https://js.foundation) project using the MIT license **AND** referencing this document in the header of the distributed Project code or Project website source code.
+
 ## Source Code
 
-jQuery Foundation projects are released under the terms of the license specified in the project's repository or if not specified, under the [MIT license](https://tldrlegal.com/license/mit-license).
+Projects referencing this document are released under the terms of the [MIT license](https://tldrlegal.com/license/mit-license).
 
-The MIT License is simple and easy to understand and it places almost no restrictions on what you can do with a jQuery Foundation project.
+The MIT License is simple and easy to understand and it places almost no restrictions on what you can do with the Project.
 
-You are free to use any jQuery Foundation project in any other project (even commercial projects) as long as the copyright header is left intact.
+You are free to use the Project in any other project (even commercial projects) as long as the copyright header is left intact.
 
 ## Sample Code
 
-All demos and examples, whether in a code project's repository or displayed on a project site, are released under the terms of the license as specified in the code repository. Many jQuery Foundation projects choose to release their sample code under the terms of [CC0](https://tldrlegal.com/l/cc0-1.0).
+All demos and examples, whether in a Project's repository or displayed on a Project site, are released under the terms of the license as specified in the relevant repository. Many Projects choose to release their sample code under the terms of [CC0](https://tldrlegal.com/l/cc0-1.0).
 
 CC0 is even more permissive than the MIT license, allowing you to use the code in any manner you want, without any copyright headers, notices, or other attribution.
 
 ## Web Sites
 
-The content on jQuery Foundation web sites are released under the terms of the license specified in the website's repository or if not specified, under the [MIT license](https://tldrlegal.com/license/mit-license).
+The content on a Project web site referencing this document in its header is released under the terms of the license specified in the website's repository or if not specified, under the [MIT license](https://tldrlegal.com/license/mit-license).
 
-**The design, layout, and look-and-feel of jQuery web sites are not licensed for use and may not be used on any site, personal or commercial, without prior written consent from the jQuery Foundation**.
+**The design, layout, and look-and-feel of JS Foundation project web sites are not licensed for use and may not be used on any site, personal or commercial, without prior written consent from the JS Foundation**.
+
+For further information regarding JS Foundation licensing and intellectual property, please review the [JS Foundation IP Policy](https://js.foundation/pdf/ip-policy.pdf).


### PR DESCRIPTION
A number of former jQuery Foundation projects reference this page in their headers instead of directly to a license description. This update allows those projects to continue using those links to this page.

Fixes jquery/jquery#3623